### PR TITLE
fix dependency

### DIFF
--- a/opentelemetry/Dockerfile
+++ b/opentelemetry/Dockerfile
@@ -1,9 +1,10 @@
-FROM python:4.9-buster
+FROM python:3.9-buster
 RUN mkdir /app
 WORKDIR /app
 ENV FLASK_APP=hello.py
 RUN pip install Flask
 RUN pip install splunk-opentelemetry[all]==0.14.0
+RUN pip install markupsafe==2.0.1
 RUN pip install redis
 RUN splk-py-trace-bootstrap
 EXPOSE 6999


### PR DESCRIPTION
fixing this error
```
web_1      | ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/usr/local/lib/python3.9/site-packages/markupsafe/__init__.py)
```